### PR TITLE
remove console warning for /js/exponea.min.js.map

### DIFF
--- a/template.js
+++ b/template.js
@@ -46,7 +46,7 @@ if (path === data.proxyJsFilePath) {
 }
 
 // Check if this Client should serve exponea.js.map file (Just only to avoid annoying error in console)
-if (path === '/exponea.min.js.map') {
+if (path === '/exponea.min.js.map' || path === '/js/exponea.min.js.map') {
     sendProxyResponse('{"version": 1, "mappings": "", "sources": [], "names": [], "file": ""}', {'Content-Type': 'application/json'}, 200);
 }
 

--- a/template.tpl
+++ b/template.tpl
@@ -144,7 +144,7 @@ if (path === data.proxyJsFilePath) {
 }
 
 // Check if this Client should serve exponea.js.map file (Just only to avoid annoying error in console)
-if (path === '/exponea.min.js.map') {
+if (path === '/exponea.min.js.map' || path === '/js/exponea.min.js.map') {
     sendProxyResponse('{"version": 1, "mappings": "", "sources": [], "names": [], "file": ""}', {'Content-Type': 'application/json'}, 200);
 }
 


### PR DESCRIPTION
After implementing I still got console warnings. Adding this second path removed it. I left the old path in case it is used by other people utilizing this template.