### PR TITLE
Allow for processing of link-ids

### DIFF
--- a/template.js
+++ b/template.js
@@ -51,7 +51,11 @@ if (path === '/exponea.min.js.map') {
 }
 
 // Check if this Client should claim request
-if (path !== '/bulk' && path !== '/managed-tags/show' && path !== '/campaigns/banners/show' && path !== ('/webxp/projects/'+data.projectToken+'/bundle')) {
+if (path !== '/bulk' 
+    && path !== '/managed-tags/show' 
+    && path !== '/campaigns/banners/show' 
+    && path !== ('/webxp/projects/'+data.projectToken+'/bundle')
+    && path.indexOf("link-ids") === -1) {
     return;
 }
 
@@ -105,7 +109,10 @@ sendHttpRequest(requestUrl, {method: requestMethod, headers: requestHeaders}, re
         }
     }
 
-    setResponseBody(result.body);
+    // link-ids request does not return any payload, so the response will fail without this condition
+    if (result.body) {
+       setResponseBody(result.body);
+    }    
     setResponseStatus(result.statusCode);
 
     if (requestOrigin) {

--- a/template.tpl
+++ b/template.tpl
@@ -153,7 +153,7 @@ if (path !== '/bulk'
     && path !== '/managed-tags/show' 
     && path !== '/campaigns/banners/show' 
     && path !== ('/webxp/projects/'+data.projectToken+'/bundle')
-    && path.indexOf("link-ids") > -1) {
+    && path.indexOf("link-ids") === -1) {
     return;
 }
 

--- a/template.tpl
+++ b/template.tpl
@@ -149,7 +149,11 @@ if (path === '/exponea.min.js.map') {
 }
 
 // Check if this Client should claim request
-if (path !== '/bulk' && path !== '/managed-tags/show' && path !== '/campaigns/banners/show' && path !== ('/webxp/projects/'+data.projectToken+'/bundle')) {
+if (path !== '/bulk' 
+    && path !== '/managed-tags/show' 
+    && path !== '/campaigns/banners/show' 
+    && path !== ('/webxp/projects/'+data.projectToken+'/bundle')
+    && path.indexOf("link-ids") > -1) {
     return;
 }
 
@@ -203,7 +207,10 @@ sendHttpRequest(requestUrl, {method: requestMethod, headers: requestHeaders}, re
         }
     }
 
-    setResponseBody(result.body);
+    // link-ids request does not return any payload, so the response will fail without this condition
+    if (result.body) {
+      setResponseBody(result.body);
+    }
     setResponseStatus(result.statusCode);
 
     if (requestOrigin) {


### PR DESCRIPTION
1. Add a condition to make sure link-ids request is not excluded
2. Add a condition to make sure the template does not try to assign response body if there is no payload in the response from Exponea APIs